### PR TITLE
workflows: docs: export VERSION to later steps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,8 @@ jobs:
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             VERSION="pr-${{ github.event.number }}"
           fi
+          echo "VERSION=${VERSION}"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
 
       - name: Prepare Azure upload
         working-directory: doc/nrf-bm/_build/html


### PR DESCRIPTION
Resolves a bug where `VERSION` would be read as
empty in the `Prepare Azure upload` step due
to the variable not being exported by the
`Check version` step.
This would cause builds generated from main branch to not include "latest" in the build.