### PR TITLE
lib: peer_manager: fix temporary peer_id from conn_handle

### DIFF
--- a/lib/peer_manager/include/modules/peer_database.h
+++ b/lib/peer_manager/include/modules/peer_database.h
@@ -18,6 +18,7 @@
 
 #include <stdint.h>
 #include <bluetooth/peer_manager/peer_manager_types.h>
+#include <nrf_sdh_ble.h>
 #include "peer_manager_internal.h"
 
 #ifdef __cplusplus
@@ -33,14 +34,28 @@ extern "C" {
 #define PDB_WRITE_BUF_SIZE (sizeof(pm_peer_data_bonding_t))
 
 /**
- * @brief Macro for creating a peer ID value from a connection handle.
+ * @brief Function for creating a peer ID value from a connection handle.
  *
- * Use this macro with pdb_write_buf_get() or pdb_write_buf_store(). It allows to create a write
- * buffer even if you do not yet know the proper peer ID the data will be stored for.
+ * Use this function with pdb_write_buf_get() or pdb_write_buf_store(). It allows to create a
+ * write buffer even if you do not yet know the proper peer ID the data will be stored for.
  *
- * @return @p conn_handle + @ref PM_PEER_ID_N_AVAILABLE_IDS.
+ * @param[in]  conn_handle  The connection handle.
+ * @param[out] peer_id      Temporary peer ID.
+ *
+ * @retval NRF_SUCCESS              Temporary peer ID written to @p peer_id.
+ * @retval NRF_ERROR_INVALID_PARAM  Connection handle was invalid.
  */
-#define PDB_TEMP_PEER_ID(conn_handle) (PM_PEER_ID_N_AVAILABLE_IDS + conn_handle)
+static inline uint32_t pdb_temp_peer_id_get(uint16_t conn_handle, pm_peer_id_t *peer_id)
+{
+	const int idx = nrf_sdh_ble_idx_get(conn_handle);
+
+	if (idx < 0) {
+		return NRF_ERROR_INVALID_PARAM;
+	}
+
+	*peer_id = PM_PEER_ID_N_AVAILABLE_IDS + idx;
+	return NRF_SUCCESS;
+}
 
 /**
  * @brief Function for initializing the module.
@@ -102,8 +117,8 @@ uint32_t pdb_peer_data_ptr_get(pm_peer_id_t peer_id, pm_peer_data_id_t data_id,
  *
  * @param[in]  peer_id      ID of the peer to get a write buffer for. If @p peer_id is larger than
  *                          @ref PM_PEER_ID_N_AVAILABLE_IDS, it is interpreted as pertaining to
- *                          the connection with connection handle peer_id -
- * PM_PEER_ID_N_AVAILABLE_IDS. See @ref PDB_TEMP_PEER_ID.
+ *                          the connection that have been assigned idx (peer_id -
+ * PM_PEER_ID_N_AVAILABLE_IDS) using @ref nrf_sdh_ble_idx_get. See @ref pdb_temp_peer_id_get.
  * @param[in]  data_id      The piece of data to get.
  * @param[in]  n_bufs       Number of contiguous buffers needed.
  * @param[out] p_peer_data  Pointers to mutable peer data.

--- a/lib/peer_manager/modules/security_dispatcher.c
+++ b/lib/peer_manager/modules/security_dispatcher.c
@@ -161,8 +161,13 @@ static void pairing_failure(uint16_t conn_handle, pm_sec_error_code_t error, uin
 	uint32_t err_code = NRF_SUCCESS;
 	pm_conn_sec_procedure_t procedure = bonding(conn_handle) ? PM_CONN_SEC_PROCEDURE_BONDING
 								 : PM_CONN_SEC_PROCEDURE_PAIRING;
+	pm_peer_id_t temp_peer_id;
 
-	err_code = pdb_write_buf_release(PDB_TEMP_PEER_ID(conn_handle), PM_PEER_DATA_ID_BONDING);
+	err_code = pdb_temp_peer_id_get(conn_handle, &temp_peer_id);
+	if (err_code == NRF_SUCCESS) {
+		err_code = pdb_write_buf_release(temp_peer_id, PM_PEER_DATA_ID_BONDING);
+	}
+
 	if ((err_code != NRF_SUCCESS) &&
 	    (err_code != NRF_ERROR_NOT_FOUND /* No buffer was allocated */)) {
 		LOG_ERR("Could not clean up after failed bonding procedure. "
@@ -522,6 +527,7 @@ static void auth_status_success_process(ble_gap_evt_t const *p_gap_evt)
 	uint32_t err_code;
 	uint16_t conn_handle = p_gap_evt->conn_handle;
 	pm_peer_id_t peer_id;
+	pm_peer_id_t temp_peer_id;
 	pm_peer_data_t peer_data;
 	bool new_peer_id = false;
 
@@ -532,8 +538,11 @@ static void auth_status_success_process(ble_gap_evt_t const *p_gap_evt)
 		return;
 	}
 
-	err_code = pdb_write_buf_get(PDB_TEMP_PEER_ID(conn_handle), PM_PEER_DATA_ID_BONDING, 1,
-				     &peer_data);
+	err_code = pdb_temp_peer_id_get(conn_handle, &temp_peer_id);
+	if (err_code == NRF_SUCCESS) {
+		err_code = pdb_write_buf_get(temp_peer_id, PM_PEER_DATA_ID_BONDING, 1, &peer_data);
+	}
+
 	if (err_code != NRF_SUCCESS) {
 		LOG_ERR("RAM buffer for new bond was unavailable. pdb_write_buf_get() "
 			"returned %s. conn_handle: %d.",
@@ -576,8 +585,7 @@ static void auth_status_success_process(ble_gap_evt_t const *p_gap_evt)
 		new_peer_id = true;
 	}
 
-	err_code = pdb_write_buf_store(PDB_TEMP_PEER_ID(conn_handle), PM_PEER_DATA_ID_BONDING,
-				       peer_id);
+	err_code = pdb_write_buf_store(temp_peer_id, PM_PEER_DATA_ID_BONDING, peer_id);
 
 	if (err_code == NRF_SUCCESS) {
 		pairing_success_evt_send(p_gap_evt, true);
@@ -725,6 +733,7 @@ static uint32_t sec_keyset_fill(uint16_t conn_handle, uint8_t role,
 				ble_gap_sec_keyset_t *p_sec_keyset)
 {
 	uint32_t err_code;
+	pm_peer_id_t temp_peer_id;
 	pm_peer_data_t peer_data;
 
 	if (p_sec_keyset == NULL) {
@@ -732,9 +741,11 @@ static uint32_t sec_keyset_fill(uint16_t conn_handle, uint8_t role,
 		return NRF_ERROR_INTERNAL;
 	}
 
-	/* Acquire a memory buffer to receive bonding data into. */
-	err_code = pdb_write_buf_get(PDB_TEMP_PEER_ID(conn_handle), PM_PEER_DATA_ID_BONDING, 1,
-				     &peer_data);
+	err_code = pdb_temp_peer_id_get(conn_handle, &temp_peer_id);
+	if (err_code == NRF_SUCCESS) {
+		/* Acquire a memory buffer to receive bonding data into. */
+		err_code = pdb_write_buf_get(temp_peer_id, PM_PEER_DATA_ID_BONDING, 1, &peer_data);
+	}
 
 	if (err_code == NRF_ERROR_BUSY) {
 		/* No action. */


### PR DESCRIPTION
A temporary peer_id was generated based on conn_handle and when conn_handle is increasing this will generate new peer_ids every time. This uncoverred a potential write_buffer_record resource allocation/deallocation issue.

These changes area way to bypass the issue that also seems to exist in nrf5.